### PR TITLE
[WIP] Gle 15 - Implemented the function to reset to initial version using papertrail.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,28 +2,42 @@ source "https://rubygems.org"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 8.0.0"
+
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
 gem "propshaft"
+
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.1"
+
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
+
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem "importmap-rails"
+
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
 gem "turbo-rails"
+
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails"
+
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
+
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
+
 # Tailwind CSS framework [https://github.com/rails/tailwindcss-rails]
 gem "tailwindcss-rails"
+
 # Devise authentication [https://github.com/heartcombo/devise]
 gem "devise"
+
+# Use PaperTrail for versioning [https://github.com/paper-trail-gem/paper_trail]
+gem "paper_trail"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,9 @@ GEM
     nokogiri (1.17.0-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    paper_trail (16.0.0)
+      activerecord (>= 6.1)
+      request_store (~> 1.4)
     parallel (1.26.3)
     parser (3.3.6.0)
       ast (~> 2.4.1)
@@ -228,6 +231,8 @@ GEM
     regexp_parser (2.9.3)
     reline (0.5.12)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -342,6 +347,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   importmap-rails
+  paper_trail
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)

--- a/app/controllers/game_states_controller.rb
+++ b/app/controllers/game_states_controller.rb
@@ -1,5 +1,5 @@
 class GameStatesController < ApplicationController
-  before_action :set_game_state, only: [ :show, :update, :destroy ]
+  before_action :set_game_state, only: %i[ show update destroy reset_to_initial ]
 
   def index
     @game_states = current_user.game_states.order(created_at: :desc)
@@ -25,6 +25,17 @@ class GameStatesController < ApplicationController
     flash[:alert] = "Could not update generation: #{e.message}"
     redirect_to @game_state
   end
+
+  def reset_to_initial
+    if @game_state.restore_initial_state
+      flash[:notice] = "Game state has been reset to its initial version."
+    else
+      flash[:alert] = "Failed to reset game state."
+    end
+
+    redirect_to @game_state
+  end
+
 
   def destroy
     @game_state.destroy

--- a/app/models/game_state.rb
+++ b/app/models/game_state.rb
@@ -1,4 +1,6 @@
 class GameState < ApplicationRecord
+  has_paper_trail on: :create, only: %i[ generation rows cols state ]
+
   belongs_to :user
 
   attr_accessor :input_file
@@ -12,6 +14,27 @@ class GameState < ApplicationRecord
   def alived_cells
     state.flatten.count { |cell| cell == "*" }
   end
+
+  def restore_initial_state
+    initial_state_str = versions.first.object_changes
+
+    # Parse the string into a hash
+    initial_state = YAML.safe_load(initial_state_str)
+
+    initial_state.each do |attribute, (old_value, new_value)|
+      if attribute == "state"
+        # Parse the new_value from a string to an array
+        new_state = JSON.parse(new_value)
+        send("#{attribute}=", new_state)
+      else
+        send("#{attribute}=", new_value)
+      end
+    end
+
+    save
+  end
+
+  private
 
   def process_file
     validate_file_type

--- a/app/views/game_states/show.html.erb
+++ b/app/views/game_states/show.html.erb
@@ -12,3 +12,4 @@
 </table>
 
 <%= button_to "Next Generation", game_state_path(@game_state), method: :patch, class: "btn btn-primary" %>
+<%= button_to "Restore Initial State", reset_to_initial_game_state_path(@game_state), method: :patch %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,5 +14,9 @@ Rails.application.routes.draw do
 
   root "home#index"
 
-  resources :game_states, except: [ :edit ]
+  resources :game_states, except: [ :edit ] do
+    member do
+      patch :reset_to_initial
+    end
+  end
 end

--- a/db/migrate/20241210171647_create_versions.rb
+++ b/db/migrate/20241210171647_create_versions.rb
@@ -1,7 +1,6 @@
 # This migration creates the `versions` table, the only schema PT requires.
 # All other migrations PT provides are optional.
 class CreateVersions < ActiveRecord::Migration[8.0]
-
   # The largest text column available in all supported RDBMS is
   # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
   # so that MySQL will use `longtext` instead of `text`.  Otherwise,

--- a/db/migrate/20241210171647_create_versions.rb
+++ b/db/migrate/20241210171647_create_versions.rb
@@ -1,0 +1,41 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[8.0]
+
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions, id: :uuid do |t|
+      # Consider using bigint type for performance if you are going to store only numeric ids.
+      # t.bigint   :whodunnit
+      t.string   :whodunnit
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      # MySQL users should use the following line for `created_at`
+      # t.datetime :created_at, limit: 6
+      t.datetime :created_at
+
+      t.string   :item_id,   null: false
+      t.string   :item_type, null: false
+      t.string   :event,     null: false
+      t.text     :object, limit: TEXT_BYTES
+    end
+    add_index :versions, %i[item_type item_id]
+  end
+end

--- a/db/migrate/20241210171648_add_object_changes_to_versions.rb
+++ b/db/migrate/20241210171648_add_object_changes_to_versions.rb
@@ -1,0 +1,12 @@
+# This migration adds the optional `object_changes` column, in which PaperTrail
+# will store the `changes` diff for each update event. See the readme for
+# details.
+class AddObjectChangesToVersions < ActiveRecord::Migration[8.0]
+  # The largest text column available in all supported RDBMS.
+  # See `create_versions.rb` for details.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    add_column :versions, :object_changes, :text, limit: TEXT_BYTES
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_09_161429) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_10_171648) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -35,6 +35,17 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_09_161429) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "versions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "whodunnit"
+    t.datetime "created_at"
+    t.string "item_id", null: false
+    t.string "item_type", null: false
+    t.string "event", null: false
+    t.text "object"
+    t.text "object_changes"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   add_foreign_key "game_states", "users"


### PR DESCRIPTION
This PR introduces PaperTrail to manage versioning for the GameState model, tracking the initial creation event. The goal is to allow restoring the game state to its original configuration.

However, the implementation currently has limitations when reifying versions because the object column in PaperTrail is nil for the create event. This forces reliance on object_changes, which requires manual YAML parsing, adding unnecessary complexity.


Why is this PR in WIP?

- The current approach relies on manually parsing object_changes to extract state and generation, which is not  an ideal or maintainable solution.
- We are exploring an alternative approach where the initial state is stored directly in the GameState model using a JSONB column (initial_file_data). This approach eliminates the need for PaperTrail in this specific case and simplifies the restore process.